### PR TITLE
Setup routing capability for the project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2
+jobs:
+ build:
+   docker:
+     - image: circleci/node:8
+   steps:
+     - checkout
+     - run:
+         name: Setup Dependencies
+         command: yarn install
+     - run:
+         name: Setup Code Climate test-reporter
+         command: |
+           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+           chmod +x ./cc-test-reporter
+     - run: # run tests
+         name: Run Test and Coverage
+         command: |
+           ./cc-test-reporter before-build
+           yarn test --coverage
+           ./cc-test-reporter after-build --exit-code $?

--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,22 @@
-import React from 'react';
-import logo from './logo.svg';
+import React, { Component } from 'react'
+import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 import './App.css';
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+class App extends Component {
+  render() {
+    return (
+      <React.Fragment>
+      <BrowserRouter>
+        <Switch>
+          <Route path="/" exact component={()=><p>Component Goes Here</p>} />
+        </Switch>
+      </BrowserRouter>
+      <ToastContainer />
+    </React.Fragment>
+    )
+  }
 }
+
 
 export default App;


### PR DESCRIPTION
## What does this PR do?
- it sets up react router
- it updates tests to pass accordingly

## Any Background Context
- initially, components are rendered through the root domain only, I added capability of specifying routes through which resources and components can be uniquely located and served to the users.

## How can this be tested?
- To test this, get the project cloned to your local machine, run `yarn install` and `yarn start`. You should see a paragraph displayed on the web page at the home page. You can add custom routes to serve a component of your own other than the paragraph that I served.

## Any Screenshots
- Not necessary
